### PR TITLE
feat: Add loader factory and raw record provenance

### DIFF
--- a/src/py_load_medgen/cli.py
+++ b/src/py_load_medgen/cli.py
@@ -9,7 +9,7 @@ from importlib import metadata
 from typing import Iterator, TypeVar
 
 from py_load_medgen.downloader import Downloader
-from py_load_medgen.loader.postgres import PostgresNativeLoader
+from py_load_medgen.loader.factory import LoaderFactory
 from py_load_medgen.sql.ddl import STAGING_CONCEPTS_DDL, STAGING_NAMES_DDL
 from py_load_medgen.parser import (
     parse_mrconso,
@@ -153,7 +153,7 @@ def main():
     total_records_loaded = 0
 
     try:
-        with PostgresNativeLoader(db_dsn=args.db_dsn) as loader:
+        with LoaderFactory.create_loader(db_dsn=args.db_dsn) as loader:
             # 1. Log the start of the run
             log_id = loader.log_run_start(
                 run_id=run_id,
@@ -226,7 +226,7 @@ def main():
         if log_id is not None:
             # Use a new loader connection in case the old one is broken
             try:
-                with PostgresNativeLoader(db_dsn=args.db_dsn) as error_loader:
+                with LoaderFactory.create_loader(db_dsn=args.db_dsn) as error_loader:
                     error_loader.log_run_finish(
                         log_id,
                         status="Failed",

--- a/src/py_load_medgen/loader/factory.py
+++ b/src/py_load_medgen/loader/factory.py
@@ -1,0 +1,40 @@
+from urllib.parse import urlparse
+
+from py_load_medgen.loader.base import AbstractNativeLoader
+from py_load_medgen.loader.postgres import PostgresNativeLoader
+
+
+class LoaderFactory:
+    """
+    A factory for creating database-specific loader instances.
+    This class is responsible for selecting the correct concrete implementation
+    of AbstractNativeLoader based on the provided database connection string (DSN).
+    """
+
+    @staticmethod
+    def create_loader(db_dsn: str) -> AbstractNativeLoader:
+        """
+        Instantiates the appropriate native loader based on the DSN scheme.
+        Args:
+            db_dsn: The database connection string.
+        Returns:
+            A concrete instance of AbstractNativeLoader.
+        Raises:
+            ValueError: If the DSN scheme is unsupported.
+        """
+        try:
+            parsed_uri = urlparse(db_dsn)
+            scheme = parsed_uri.scheme
+        except Exception as e:
+            raise ValueError(f"Could not parse database DSN: {e}") from e
+
+        if not scheme:
+            raise ValueError("Could not parse database DSN: scheme is missing.")
+
+        if scheme in ("postgres", "postgresql"):
+            return PostgresNativeLoader(db_dsn=db_dsn)
+        # Placeholder for future implementations
+        # elif scheme == "redshift":
+        #     return RedshiftNativeLoader(db_dsn=db_dsn)
+        else:
+            raise ValueError(f"Unsupported database scheme: '{scheme}'. Supported schemes are: 'postgresql'.")

--- a/src/py_load_medgen/parser.py
+++ b/src/py_load_medgen/parser.py
@@ -28,6 +28,7 @@ class MrconsoRecord:
     srl: str
     suppress: str
     cvf: Optional[str]
+    raw_record: str
 
 
 import csv
@@ -52,6 +53,7 @@ class MedgenName:
     name: str
     source: str
     suppress: str
+    raw_record: str
 
 
 def stream_mrconso_tsv(records: Iterator[MrconsoRecord]) -> Iterator[bytes]:
@@ -81,19 +83,25 @@ def stream_names_tsv(records: Iterator[MedgenName]) -> Iterator[bytes]:
 def parse_mrconso(file_stream: IO[str]) -> Iterator[MrconsoRecord]:
     """
     Parses a pipe-delimited MRCONSO.RRF file stream.
-
     Args:
         file_stream: A text file-like object containing MRCONSO.RRF data.
-
     Yields:
         MrconsoRecord instances for each valid row in the file.
     """
     # The RRF format is pipe-delimited, and each row ends with a pipe.
-    reader = csv.reader(file_stream, delimiter="|", quotechar="\\")
-    for i, row in enumerate(reader):
+    # We can't use the csv module directly with the file_stream iterator
+    # because we need to preserve the raw line.
+    for i, line in enumerate(file_stream):
+        raw_line = line.strip()
+        if not raw_line:
+            continue
+
+        row = raw_line.split("|")
         # After splitting, a valid row will have 19 elements, with the last one being empty.
         if len(row) < 18:
-            logging.warning(f"Skipping malformed row {i+1}: expected 18 columns, found {len(row) - 1}")
+            logging.warning(
+                f"Skipping malformed row {i+1}: expected 18 columns, found {len(row) - 1}"
+            )
             continue
 
         # Unpack the row into the dataclass fields.
@@ -119,6 +127,7 @@ def parse_mrconso(file_stream: IO[str]) -> Iterator[MrconsoRecord]:
                 srl=row[15],
                 suppress=row[16],
                 cvf=row[17] if row[17] else None,
+                raw_record=raw_line,
             )
         except IndexError:
             logging.warning(f"Skipping malformed row {i+1}: not enough columns.")
@@ -127,23 +136,28 @@ def parse_mrconso(file_stream: IO[str]) -> Iterator[MrconsoRecord]:
 def parse_names(file_path: Path) -> Iterator[MedgenName]:
     """
     Parses a gzipped, pipe-delimited NAMES.RRF.gz file.
-
     Args:
         file_path: Path to the gzipped file.
-
     Yields:
         MedgenName instances for each valid row in the file.
     """
     with gzip.open(file_path, "rt", encoding="utf-8") as f:
-        reader = csv.reader(f, delimiter="|")
-        header = next(reader)  # Skip header
-        if not header[0].startswith("#CUI"):
+        # Skip header
+        header = f.readline()
+        if not header.startswith("#CUI"):
             logging.warning("NAMES.RRF file does not have the expected header.")
 
-        for i, row in enumerate(reader):
+        for i, line in enumerate(f):
+            raw_line = line.strip()
+            if not raw_line:
+                continue
+
+            row = raw_line.split("|")
             # Each row should have 5 elements, with the last one being empty.
             if len(row) < 5:
-                logging.warning(f"Skipping malformed row {i+1} in NAMES.RRF: expected 4 columns, found {len(row) - 1}")
+                logging.warning(
+                    f"Skipping malformed row {i+1} in NAMES.RRF: expected 4 columns, found {len(row) - 1}"
+                )
                 continue
 
             yield MedgenName(
@@ -151,4 +165,5 @@ def parse_names(file_path: Path) -> Iterator[MedgenName]:
                 name=row[1],
                 source=row[2],
                 suppress=row[3],
+                raw_record=raw_line,
             )

--- a/src/py_load_medgen/sql/ddl.py
+++ b/src/py_load_medgen/sql/ddl.py
@@ -39,7 +39,8 @@ CREATE UNLOGGED TABLE IF NOT EXISTS staging_medgen_concepts (
     str TEXT NOT NULL,
     srl VARCHAR(10) NOT NULL,
     suppress CHAR(1) NOT NULL,
-    cvf VARCHAR(50)
+    cvf VARCHAR(50),
+    raw_record TEXT
 );
 """
 
@@ -48,6 +49,7 @@ CREATE UNLOGGED TABLE IF NOT EXISTS staging_medgen_names (
     cui VARCHAR(10) NOT NULL,
     name TEXT NOT NULL,
     source VARCHAR(40) NOT NULL,
-    suppress CHAR(1) NOT NULL
+    suppress CHAR(1) NOT NULL,
+    raw_record TEXT
 );
 """

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -1,0 +1,35 @@
+import pytest
+from py_load_medgen.loader.factory import LoaderFactory
+from py_load_medgen.loader.postgres import PostgresNativeLoader
+
+
+@pytest.mark.unit
+def test_loader_factory_returns_postgres_loader():
+    """
+    Tests that the LoaderFactory correctly returns a PostgresNativeLoader
+    for a valid PostgreSQL DSN.
+    """
+    dsn = "postgresql://user:pass@host:5432/dbname"
+    loader = LoaderFactory.create_loader(dsn)
+    assert isinstance(loader, PostgresNativeLoader)
+    assert loader.dsn == dsn
+
+
+@pytest.mark.unit
+def test_loader_factory_raises_error_for_unsupported_scheme():
+    """
+    Tests that the LoaderFactory raises a ValueError for an unsupported DSN scheme.
+    """
+    dsn = "mysql://user:pass@host:3306/dbname"
+    with pytest.raises(ValueError, match="Unsupported database scheme: 'mysql'"):
+        LoaderFactory.create_loader(dsn)
+
+
+@pytest.mark.unit
+def test_loader_factory_raises_error_for_malformed_dsn():
+    """
+    Tests that the LoaderFactory raises a ValueError for a malformed DSN.
+    """
+    dsn = "not-a-valid-dsn"
+    with pytest.raises(ValueError, match="Could not parse database DSN"):
+        LoaderFactory.create_loader(dsn)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -41,9 +41,10 @@ def setup_teardown_tables(postgresql):
 
 
 @pytest.mark.integration
-def test_staging_load(postgresql):
+def test_staging_load_with_raw_record(postgresql):
     """
-    Tests loading data into a staging table using the streaming pipeline.
+    Tests loading data into a staging table using the streaming pipeline
+    and verifies the raw_record column.
     """
     with PostgresNativeLoader(connection=postgresql, autocommit=False) as loader:
         # 1. Initialize
@@ -57,14 +58,17 @@ def test_staging_load(postgresql):
 
         # 3. Assert
         with postgresql.cursor() as cur:
-            cur.execute(f"SELECT COUNT(*) FROM {STAGING_TABLE}")
-            assert cur.fetchone()[0] == 3
+            cur.execute(f"SELECT COUNT(*), MIN(raw_record) FROM {STAGING_TABLE}")
+            count, raw_record = cur.fetchone()
+            assert count == 3
+            assert raw_record == SAMPLE_MRCONSO_DATA.splitlines()[0]
 
 
 @pytest.mark.integration
-def test_full_load_atomic_swap(postgresql):
+def test_full_load_atomic_swap_with_raw_record(postgresql):
     """
-    Tests the full load process, including atomic swap and cleanup.
+    Tests the full load process, including atomic swap and cleanup,
+    and verifies the raw_record column in the final production table.
     """
     backup_table = f"{PRODUCTION_TABLE}_old"
 
@@ -83,10 +87,11 @@ def test_full_load_atomic_swap(postgresql):
         # Check that data is in the production table
         cur.execute(f"SELECT COUNT(*) FROM {PRODUCTION_TABLE}")
         assert cur.fetchone()[0] == 3
-        cur.execute(f"SELECT cui, str FROM {PRODUCTION_TABLE} WHERE aui = 'A0019182'")
+        cur.execute(f"SELECT cui, str, raw_record FROM {PRODUCTION_TABLE} WHERE aui = 'A0019182'")
         record = cur.fetchone()
         assert record[0] == "C0001175"
         assert record[1] == "Acquired Immunodeficiency Syndromes"
+        assert record[2] == SAMPLE_MRCONSO_DATA.splitlines()[0]
 
         # Check that the staging and backup tables are gone
         def table_exists(cursor, table_name):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,17 +1,18 @@
 import gzip
+import io
 from pathlib import Path
 
-from py_load_medgen.parser import MedgenName, parse_names
+from py_load_medgen.parser import MedgenName, MrconsoRecord, parse_names, parse_mrconso
 
 
-def test_parse_names(tmp_path: Path):
+def test_parse_names_and_raw_record(tmp_path: Path):
     """
     Tests that the parse_names function correctly parses a gzipped,
-    pipe-delimited NAMES.RRF file.
+    pipe-delimited NAMES.RRF file and captures the raw record.
     """
     # 1. Arrange: Create a dummy gzipped NAMES.RRF file
     file_path = tmp_path / "NAMES.RRF.gz"
-    content = [
+    content_lines = [
         "#CUI|name|source|SUPPRESS|",
         "C0000727|Acute abdomen|GTR|N|",
         "C0000729|Abdominal cramps|GTR|N|",
@@ -21,15 +22,55 @@ def test_parse_names(tmp_path: Path):
         "C0000736|Missing pipe", # Malformed row
     ]
     with gzip.open(file_path, "wt", encoding="utf-8") as f:
-        f.write("\n".join(content))
+        f.write("\n".join(content_lines))
 
     # 2. Act: Parse the file
     records = list(parse_names(file_path))
 
     # 3. Assert
     assert len(records) == 5
-    assert records[0] == MedgenName(cui="C0000727", name="Acute abdomen", source="GTR", suppress="N")
-    assert records[1] == MedgenName(cui="C0000729", name="Abdominal cramps", source="GTR", suppress="N")
-    assert records[2] == MedgenName(cui="C0000731", name="Abdominal distention", source="GTR", suppress="Y")
-    assert records[3] == MedgenName(cui="C0000734", name="Abdominal mass", source="GTR", suppress="N")
-    assert records[4] == MedgenName(cui="C0000735", name="", source="GTR", suppress="N")
+    assert records[0] == MedgenName(
+        cui="C0000727", name="Acute abdomen", source="GTR", suppress="N", raw_record=content_lines[1]
+    )
+    assert records[1] == MedgenName(
+        cui="C0000729", name="Abdominal cramps", source="GTR", suppress="N", raw_record=content_lines[2]
+    )
+    assert records[2] == MedgenName(
+        cui="C0000731", name="Abdominal distention", source="GTR", suppress="Y", raw_record=content_lines[3]
+    )
+    assert records[3] == MedgenName(
+        cui="C0000734", name="Abdominal mass", source="GTR", suppress="N", raw_record=content_lines[4]
+    )
+    assert records[4] == MedgenName(
+        cui="C0000735", name="", source="GTR", suppress="N", raw_record=content_lines[5]
+    )
+
+
+def test_parse_mrconso_and_raw_record():
+    """
+    Tests that the parse_mrconso function correctly parses a pipe-delimited
+    MRCONSO.RRF file stream and captures the raw record.
+    """
+    # 1. Arrange: Create a dummy MRCONSO.RRF file stream
+    content_lines = [
+        "C0000005|ENG|P|L0000005|PF|S0007492|Y|A26634265||M0019694|D012711|MSH|PEN|D012711|(131)I-Macroaggregated Albumin|0|N|256|",
+        "C0000039|ENG|P|L0000039|PF|S0007563|Y|A26634304||M0023172|D015060|MSH|PEP|D015060|1,2-Dipalmitoylphosphatidylcholine|3|N||",
+        "C0000039|ENG|S|L0000039|VO|S0007564|N|A26634305||M0023172|D015060|MSH|EN|D015060|1,2 Dipalmitoylphosphatidylcholine|3|N|256|",
+        "C0000039|ENG|S|L0000039|VO|S0352885|N|A29142011||M0023172|D015060|MSH|ET|D015060|1,2-Dipalmitoyl Phosphatidylcholine|3|N|256|",
+    ]
+    file_stream = io.StringIO("\n".join(content_lines))
+
+    # 2. Act: Parse the file
+    records = list(parse_mrconso(file_stream))
+
+    # 3. Assert
+    assert len(records) == 4
+    assert records[0] == MrconsoRecord(
+        cui='C0000005', lat='ENG', ts='P', lui='L0000005', stt='PF', sui='S0007492', ispref='Y', aui='A26634265',
+        saui=None, scui='M0019694', sdui='D012711', sab='MSH', tty='PEN', code='D012711',
+        str='(131)I-Macroaggregated Albumin', srl='0', suppress='N', cvf='256', raw_record=content_lines[0]
+    )
+    assert records[1].cui == "C0000039"
+    assert records[1].raw_record == content_lines[1]
+    assert records[3].ispref == "N"
+    assert records[3].raw_record == content_lines[3]


### PR DESCRIPTION
This commit introduces two new features based on the FRD:

1.  **Loader Factory (R-4.3.2):**
    -   A `LoaderFactory` has been added to decouple the application from concrete database implementations.
    -   The CLI now uses the factory to create a loader based on the DSN scheme, improving modularity and extensibility.
    -   Added unit tests for the factory to ensure it handles valid, invalid, and malformed DSNs correctly.

2.  **Raw Data Provenance (R-2.3.2):**
    -   The parsers now capture the original raw line for each record.
    -   This raw record is stored in a `raw_record` TEXT column in the database for auditability.
    -   Updated DDL, dataclasses, parsers, and integration tests to support this feature end-to-end.