### PR TITLE
feat: Populate MedGen release version in audit log

### DIFF
--- a/src/py_load_medgen/cli.py
+++ b/src/py_load_medgen/cli.py
@@ -244,9 +244,6 @@ def main():
                 # Prepare source file info for logging
                 source_file_checksums[remote_file] = checksums.get(remote_file)
 
-        # Add release version to the source file metadata
-        source_file_checksums["release_version"] = release_version
-
     except Exception as e:
         logging.error(f"Failed during download phase: {e}", exc_info=True)
         sys.exit(1)
@@ -264,6 +261,7 @@ def main():
                 package_version=pkg_version,
                 load_mode=args.mode,
                 source_files=source_file_checksums,
+                medgen_release_version=release_version,
             )
 
             for config in ETL_CONFIG:

--- a/src/py_load_medgen/loader/postgres.py
+++ b/src/py_load_medgen/loader/postgres.py
@@ -122,16 +122,32 @@ class PostgresNativeLoader(AbstractNativeLoader):
         logging.info("Metadata tables initialized.")
 
     def log_run_start(
-        self, run_id: uuid.UUID, package_version: str, load_mode: str, source_files: dict
+        self,
+        run_id: uuid.UUID,
+        package_version: str,
+        load_mode: str,
+        source_files: dict,
+        medgen_release_version: Optional[str] = None,
     ) -> int:
         """Logs the start of an ETL run and returns the log_id."""
         if not self.conn:
             raise ConnectionError("Database connection not established.")
-        sql = "INSERT INTO etl_audit_log (run_id, package_version, load_mode, source_files, start_time, status) VALUES (%s, %s, %s, %s, %s, %s) RETURNING log_id;"
+        sql = "INSERT INTO etl_audit_log (run_id, package_version, load_mode, source_files, medgen_release_version, start_time, status) VALUES (%s, %s, %s, %s, %s, %s, %s) RETURNING log_id;"
         start_time = datetime.now(timezone.utc)
         source_files_json = psycopg.types.json.Jsonb(source_files)
         with self.conn.cursor() as cur:
-            cur.execute(sql, (run_id, package_version, load_mode, source_files_json, start_time, "In Progress"))
+            cur.execute(
+                sql,
+                (
+                    run_id,
+                    package_version,
+                    load_mode,
+                    source_files_json,
+                    medgen_release_version,
+                    start_time,
+                    "In Progress",
+                ),
+            )
             log_id = cur.fetchone()[0]
             self._commit()
         logging.info(f"ETL run started. Log ID: {log_id}")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -128,6 +128,7 @@ def test_metadata_logging(postgres_db_dsn):
     Tests metadata logging using a testcontainers database.
     """
     run_id = uuid.uuid4()
+    release_version = "Test Release 2025-09-07"
 
     # The 'with' statement ensures loader.connect() is called, which creates metadata tables.
     with PostgresNativeLoader(db_dsn=postgres_db_dsn, autocommit=True) as loader:
@@ -137,14 +138,19 @@ def test_metadata_logging(postgres_db_dsn):
             package_version="0.1.0-test",
             load_mode="full",
             source_files={"MRCONSO.RRF": "d41d8cd98f00b204e9800998ecf8427e"},
+            medgen_release_version=release_version,
         )
         assert log_id is not None
 
         with loader.conn.cursor() as cur:
-            cur.execute("SELECT status, package_version FROM etl_audit_log WHERE log_id = %s", (log_id,))
+            cur.execute(
+                "SELECT status, package_version, medgen_release_version FROM etl_audit_log WHERE log_id = %s",
+                (log_id,),
+            )
             record = cur.fetchone()
             assert record[0] == "In Progress"
             assert record[1] == "0.1.0-test"
+            assert record[2] == release_version
 
         # 2. Test log_run_finish
         loader.log_run_finish(


### PR DESCRIPTION
This commit implements the functionality to capture and store the MedGen release version during the ETL process, fulfilling requirement R-2.4.2 from the FRD.

The following changes were made:
- The `PostgresNativeLoader.log_run_start` method was updated to accept a `medgen_release_version` parameter and insert it into the `etl_audit_log` table. The database schema already contained the necessary column.
- The CLI orchestrator in `cli.py` was updated to pass the release version, fetched by the existing `Downloader.get_release_version` method, to the loader.
- The integration test `test_metadata_logging` was updated to verify that the release version is correctly persisted in the database.